### PR TITLE
Query data API capability

### DIFF
--- a/data-review-assignment/src/components/DataReviewTable.tsx
+++ b/data-review-assignment/src/components/DataReviewTable.tsx
@@ -3,14 +3,36 @@
 import { useEffect, useState } from "react";
 
 export default function DataReviewTable() {
+    const [data, setData] = useState([]);
+    const [loading, setLoading] = useState(true);
 
     useEffect(() => {
+        const fetchData = async () => {
+            try {
+                const response = await fetch('/api/data');
+                if (!response.ok) {
+                    throw new Error('Network response was not ok');
+                }
+                const jsonData = await response.json();
+                setData(jsonData);
+            } catch (err) {
+                throw new Error('Error fetching data:');
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        fetchData();
     }, []);
 
     return (
         <div style={{ margin: "20px" }}>
             <h1>Data Review</h1>
             {/* Candidates will replace this placeholder with table, tooltips, and modals */}
+        
+            {loading ? <div>Loading...</div> :
+                <pre>{JSON.stringify(data, null, 2)}</pre>
+            }
         </div>
     );
 }

--- a/data-review-assignment/src/pages/api/data.ts
+++ b/data-review-assignment/src/pages/api/data.ts
@@ -4,5 +4,13 @@ import { MOCK_DATA } from "@/src/consts/data";
 import { NextApiRequest, NextApiResponse } from "next";
 
 export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  res.status(200).json(MOCK_DATA);
+  if (req.method !== 'GET') {
+    return res.status(405).json({ message: 'Method not allowed' })
+  }
+
+  try {
+    res.status(200).json(MOCK_DATA);
+  } catch (error) {
+    res.status(500).json({ message: `Internal server error: ${error}` });
+  }
 }


### PR DESCRIPTION
## What Changed? Why?
Implemented a Next.js API route that returns the provided mock JSON data

## Success metrics
- /api/data now reads the mock JSON data
- Raw JSON data is now displayed pretty in the DataReviewTable component